### PR TITLE
Normalized `Q` type in `const`

### DIFF
--- a/coq/Cn/Terms.v
+++ b/coq/Cn/Terms.v
@@ -1,7 +1,7 @@
 Require Import ZArith.
 Require Import String.
 Require Import List.
-Require Import QArith.
+Require Import QArith.Qcanon.
 Require Import Cerberus.Symbol.
 Require Import BaseTypes.
 Require Import Cerberus.Location.
@@ -13,7 +13,7 @@ Require Import Cerberus.IntegerType.
 Inductive const : Type :=
   | Z : Z -> const
   | Bits : (BaseTypes.sign * nat) * Z -> const
-  | Q : Q -> const  (* Note: Q needs to be defined or imported *)
+  | Q : Qc -> const  (* Note: Q needs to be defined or imported *)
   | MemByte : Z * Z -> const  (* alloc_id * value *)
   | Pointer : Z * Z -> const  (* alloc_id * addr *)
   | Alloc_id : Z -> const

--- a/coq/Cn/Terms.v
+++ b/coq/Cn/Terms.v
@@ -13,7 +13,7 @@ Require Import Cerberus.IntegerType.
 Inductive const : Type :=
   | Z : Z -> const
   | Bits : (BaseTypes.sign * nat) * Z -> const
-  | Q : Qc -> const  (* Note: Q needs to be defined or imported *)
+  | Q : Qc -> const
   | MemByte : Z * Z -> const  (* alloc_id * value *)
   | Pointer : Z * Z -> const  (* alloc_id * addr *)
   | Alloc_id : Z -> const

--- a/lib/pp_mucore_coq.ml
+++ b/lib/pp_mucore_coq.ml
@@ -14,7 +14,7 @@ let pp_Z z =
   if Z.lt z Z.zero then !^("(" ^ s ^ ")%Z") else !^(s ^ "%Z")
 
 
-let pp_Q q = !^("(" ^ Q.to_string q ^ ")%Q")
+let pp_Q q = !^("(" ^ "Q2Qc" ^ "(" ^ Q.to_string q ^ ")%Q)")
 
 (* Prints int as a Coq `nat` *)
 let pp_nat n = !^(string_of_int n)


### PR DESCRIPTION
Use canonical representation of rational numbers for representation of constants in Coq.

This pull request should close issue #3 