### PR TITLE
Perform simplification on resources in hints

### DIFF
--- a/lib/typing.ml
+++ b/lib/typing.ml
@@ -714,10 +714,14 @@ let do_unfold_resources loc =
                 match unpackable with
                 | `LRT lrt -> (re, UnpackLRT lrt)
                 | `RES res ->
-                  let res_simp = List.map (fun (r, Res.O oargs) ->
-                    let r = Simplify.Request.simp simp_ctxt r in
-                    let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
-                    (r, Res.O oargs)) res in
+                  let res_simp =
+                    List.map
+                      (fun (r, Res.O oargs) ->
+                         let r = Simplify.Request.simp simp_ctxt r in
+                         let oargs = Simplify.IndexTerms.simp simp_ctxt oargs in
+                         (r, Res.O oargs))
+                      res
+                  in
                   (re, UnpackRES res_simp))
              unpack
          in


### PR DESCRIPTION
This PR fixes a problem with `arrow_access.c` example