### PR TITLE
Prove `unfold_all_explicit_fun_eq`

### DIFF
--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -651,6 +651,15 @@ Proof.
   - eapply unfold_all_fixpoint; eassumption.
 Qed.
 
+Definition resource_is_struct (r : Resource.t): bool :=
+  match r with
+  | (Request.P {| Predicate.name := Request.Owned (SCtypes.Struct _) _;
+                  Predicate.pointer := _;
+                  Predicate.iargs := _ |}, _) =>
+    true
+  | _ => false
+  end.
+
 (* Computable version of unfold_all_explicit predicate *)
 Fixpoint unfold_all_explicit_fun
   (globals:Global.t)
@@ -662,7 +671,9 @@ Fixpoint unfold_all_explicit_fun
     List.existsb (fun r' => bool_of_sum (Resource_as_DecidableType.eq_dec r r')) input &&
     unfold_one_fun globals r unfolded_r_list &&
     unfold_all_explicit_fun globals unfold_changed input' output
-  | [] => ResSet.equal (Resource.set_from_list input) (Resource.set_from_list output)
+  | [] =>
+    negb (List.existsb resource_is_struct input) && (* this should be updated later to support arrays *)
+    ResSet.equal (Resource.set_from_list input) (Resource.set_from_list output)
   | _ => false
   end.
 

--- a/coq/Reasoning/ResourceInference.v
+++ b/coq/Reasoning/ResourceInference.v
@@ -608,12 +608,13 @@ Inductive unfold_all (globals:Global.t): ResSet.t -> ResSet.t -> Prop :=
     (* This is the result of unfolding the input *)
     unfold_all globals input output
 | unfold_all_fixpoint:
-    forall input,
+    forall input output,
     (* A fixpoint is reached when no resource can be unfolded further *)
     ~ ResSet.Exists
         (fun r => exists unfolded_r, unfold_one globals r unfolded_r)
         input ->
-    unfold_all globals input input.
+    ResSet.Equal input output ->
+    unfold_all globals input output.
 
 (* A version of `unfold_all`, using hints *)
 Inductive unfold_all_explicit (globals:Global.t):
@@ -630,12 +631,13 @@ Inductive unfold_all_explicit (globals:Global.t):
     (* This is the result of unfolding the input *)
     unfold_all_explicit globals ((r, UnpackRES unfolded_r_list) :: unfold_changed) input output
 | unfold_all_explicit_fixpoint:
-    forall input,
+    forall input output,
     (* A fixpoint is reached when no resource can be unfolded further *)
     ~ ResSet.Exists
         (fun r => exists unfolded_r, unfold_one globals r unfolded_r)
         input ->
-    unfold_all_explicit globals [] input input.
+    ResSet.Equal input output ->
+    unfold_all_explicit globals [] input output.
 
 (* Proof that unfold_all_explicit is equivalent to unfold_all *)    
 Lemma unfold_all_explicit_eq:
@@ -645,8 +647,8 @@ Lemma unfold_all_explicit_eq:
 Proof.
   intros globals input output unfold_changed H.
   induction H.
-  - econstructor; eassumption.
-  - econstructor; eassumption.
+  - eapply unfold_all_step; eassumption.
+  - eapply unfold_all_fixpoint; eassumption.
 Qed.
 
 (* Computable version of unfold_all_explicit predicate *)


### PR DESCRIPTION
This PR:
- requires input and output to be equal under the `ResSet.Equal` relation rather than exactly identical in `unfold_all_fixpoint` constructor
-  adds a check in `unfold_all_explicit_fun` that when the list of hints is empty the input resources do not contain structs, from which it can be proven that they can't be unfolded
- adds a proof of `unfold_all_explicit_fun_eq` for the necessary direction (functional implies inductive) 