### PR TITLE
Ensure use of the right context in hints simplification

### DIFF
--- a/lib/prooflog.ml
+++ b/lib/prooflog.ml
@@ -42,27 +42,3 @@ let add_log_entry entry =
 let get_proof_log () = !proof_log
 
 let record_resource_inference_step entry = add_log_entry entry
-
-let rec simplify_proof_log_entry simp_ctxt log_entry =
-  match log_entry with
-  | PredicateRequest (ic, s, req, (p, Resource.O o), log, oc) ->
-    let p_simp = Simplify.Request.Predicate.simp simp_ctxt p in
-    let o_simp = Simplify.IndexTerms.simp ~inline_symbols:false simp_ctxt o in
-    let log_simp = simplify_proof_log simp_ctxt log in
-    PredicateRequest (ic, s, req, (p_simp, Resource.O o_simp), log_simp, oc)
-  | _ -> log_entry
-
-
-and simplify_proof_log simp_ctxt log = List.map (simplify_proof_log_entry simp_ctxt) log
-
-(* these versions of functions simplify only the inner proof log steps, which are used for hints *)
-let simplify_hints_proof_log_entry simp_ctxt log_entry =
-  match log_entry with
-  | PredicateRequest (ic, s, req, r, log, oc) ->
-    let log_simp = simplify_proof_log simp_ctxt log in
-    PredicateRequest (ic, s, req, r, log_simp, oc)
-  | _ -> log_entry
-
-
-let simplify_hints_proof_log simp_ctxt log =
-  List.map (simplify_hints_proof_log_entry simp_ctxt) log

--- a/lib/prooflog.mli
+++ b/lib/prooflog.mli
@@ -29,11 +29,3 @@ val add_log_entry : log_entry -> unit
 val get_proof_log : unit -> log_entry list
 
 val record_resource_inference_step : log_entry -> unit
-
-val simplify_proof_log_entry : Simplify.simp_ctxt -> log_entry -> log_entry
-
-val simplify_proof_log : Simplify.simp_ctxt -> log -> log
-
-val simplify_hints_proof_log_entry : Simplify.simp_ctxt -> log_entry -> log_entry
-
-val simplify_hints_proof_log : Simplify.simp_ctxt -> log -> log

--- a/lib/resourceInference.ml
+++ b/lib/resourceInference.ml
@@ -458,10 +458,8 @@ module General = struct
     (* We started with top-level call of ftyp_args_request_step, so we need to
        record the resource inference steps for the inner calls. They not nested
        under anything, so we need to record them separately. *)
-    let@ simp_ctxt = simp_ctxt () in
-    if Prooflog.is_enabled () then (
-      let l_simp = Prooflog.simplify_hints_proof_log simp_ctxt l in
-      List.iter Prooflog.record_resource_inference_step l_simp)
+    if Prooflog.is_enabled () then
+      List.iter Prooflog.record_resource_inference_step l
     else
       ();
     return rt
@@ -492,11 +490,9 @@ module Special = struct
     match result with
     | Some (r, rw_time, log) ->
       let@ c' = get_typing_context () in
-      let@ simp_ctxt = simp_ctxt () in
-      if Prooflog.is_enabled () then (
-        let log_simp = Prooflog.simplify_proof_log simp_ctxt log in
+      if Prooflog.is_enabled () then
         Prooflog.record_resource_inference_step
-          (Prooflog.PredicateRequest (c, fst uiinfo, request, r, log_simp, c')))
+          (Prooflog.PredicateRequest (c, fst uiinfo, request, r, log, c'))
       else
         ();
       return (r, rw_time)

--- a/lib/simplify.ml
+++ b/lib/simplify.ml
@@ -198,20 +198,17 @@ module IndexTerms = struct
     | _ -> IT.num_lit_ z bt
 
 
-  let rec simp ?(inline_functions = false) ?(inline_symbols = true) simp_ctxt =
-    let aux it = simp ~inline_functions ~inline_symbols simp_ctxt it in
+  let rec simp ?(inline_functions = false) simp_ctxt =
+    let aux it = simp ~inline_functions simp_ctxt it in
     fun it ->
       let the_term = match simp_ctxt.simp_hook it with None -> it | Some it' -> it' in
       let (IT (the_term_, the_bt, the_loc)) = the_term in
       match the_term_ with
       | Sym _ when BT.equal the_bt BT.Unit -> unit_ the_loc
       | Sym sym ->
-        if not inline_symbols then
-          IT (Sym sym, the_bt, the_loc)
-        else (
-          match Sym.Map.find_opt sym simp_ctxt.values with
-          | Some (IT ((Const _ | Sym _), _, _) as v) -> v
-          | _ -> the_term)
+        (match Sym.Map.find_opt sym simp_ctxt.values with
+         | Some (IT ((Const _ | Sym _), _, _) as v) -> v
+         | _ -> the_term)
       | Const _ -> the_term
       | Binop (Add, a, b) ->
         let a = aux a in


### PR DESCRIPTION
Restore previous approach to hints simplification to ensure use of the right context